### PR TITLE
Replacing print statements with logging statements

### DIFF
--- a/pyknotid/representations/gausscode.py
+++ b/pyknotid/representations/gausscode.py
@@ -15,6 +15,7 @@ from __future__ import print_function
 import numpy as n
 import re
 import sys
+import logging
 
 
 class GaussCode(object):
@@ -101,7 +102,7 @@ class GaussCode(object):
         from pyknotid.representations import representation
         rep = representation.Representation(gc)
         # rep.draw_planar_graph()
-        # print('ready to do space curve')
+        # logging.info('ready to do space curve')
         sp = rep.space_curve()
         # sp.rotate()
         return sp.gauss_code()
@@ -271,7 +272,6 @@ class GaussCode(object):
         # Next do RM1_extended separately (could be more efficient?)
         if one_extended:
             # Do extended RM1 as a separate step
-            print
             code = [(line[keep] if len(line) > 0 else line) for (line, keep) in zip(code, keeps)]
             keeps = [n.ones(l.shape[0], dtype=bool) for l in code]
 
@@ -365,7 +365,7 @@ class GaussCode(object):
         '''
 
         if self.verbose:
-            print('Simplifying: initially {} crossings'.format(
+            logging.info('Simplifying: initially {} crossings'.format(
                 n.sum([len(line) for line in self._gauss_code])))
 
         number_of_runs = 0
@@ -377,14 +377,10 @@ class GaussCode(object):
             new_len = n.sum([len(line) for line in new_gc])
             number_of_runs += 1
             if self.verbose:
-                sys.stdout.write('\r-> {} crossings after {} runs'.format(
+                logging.info('\r-> {} crossings after {} runs'.format(
                     n.sum([len(line) for line in new_gc]), number_of_runs))
-                sys.stdout.flush()
             if new_len == original_len:
                 break
-
-        if self.verbose:
-            print()
 
     def reindex_crossings(self):
         '''Replaces the indices of the crossings in the Gauss code with the
@@ -429,4 +425,3 @@ def _get_crossing_numbers(gc):
         for entry in line:
             crossing_vals.add(entry[0])
     return crossing_vals
-

--- a/pyknotid/spacecurves/link.py
+++ b/pyknotid/spacecurves/link.py
@@ -25,9 +25,10 @@ except:
 from pyknotid.spacecurves import helpers
 from pyknotid.spacecurves.knot import Knot
 from pyknotid.visualise import plot_projection
-from pyknotid.utils import (vprint, get_rotation_matrix,
+from pyknotid.utils import (get_rotation_matrix,
                            ensure_shape_tuple)
 
+import logging
 
 class Link(object):
     '''
@@ -169,7 +170,7 @@ class Link(object):
         if only_with_other_lines:
             crossings = [[] for _ in lines]
         else:
-            self._vprint('Calculating self-crossings for all {} '
+            logging.info('Calculating self-crossings for all {} '
                          'component lines'.format(len(lines)))
             crossings = [k.raw_crossings(
                 mode=mode, include_closure=include_closures,
@@ -197,7 +198,7 @@ class Link(object):
 
         for line_index, line in enumerate(lines):
             for other_index, other_line in enumerate(lines[line_index+1:]):
-                self._vprint(
+                logging.info(
                     '\rComparing line {} with {}'.format(line_index,
                                                          other_index))
 
@@ -219,7 +220,7 @@ class Link(object):
 
                 for i in first_line_range:
                     if i % 1000 == 0:
-                        self._vprint(
+                        logging.info(
                             '\ri = {} / {}'.format(
                                 i, len(first_line_range)), False)
                     v0 = points[i]
@@ -246,7 +247,7 @@ class Link(object):
                     crossings[line_index].extend(first_crossings.tolist())
                     crossings[other_index].extend(sec_crossings.tolist())
 
-        self._vprint('\n{} crossings found\n'.format(
+        logging.info('\n{} crossings found\n'.format(
             [len(cs) / 2 for cs in crossings]))
         [cs.sort(key=lambda s: s[0]) for cs in crossings]
         crossings = [n.array(cs) for cs in crossings]
@@ -386,7 +387,7 @@ class Link(object):
             line.points = remove_nearby_points(line.points)
         for i in range(runs):
             if n.sum([len(knot.points) for knot in self.lines]) > 30:
-                vprint('\rRun {} of {}, {} points remain'.format(
+                logging.info('\rRun {} of {}, {} points remain'.format(
                     i, runs, len(self)), False, self.verbose)
 
             if rotate:
@@ -409,7 +410,7 @@ class Link(object):
             if plot:
                 self.plot()
 
-        vprint('\nReduced to {} points'.format(len(self)))
+        logging.info('\nReduced to {} points'.format(len(self)))
 
     def __len__(self):
         return n.sum(map(len, self.lines))
@@ -426,12 +427,6 @@ class Link(object):
         '''
         return n.sum(k.arclength(include_closures) for k in self.lines)
 
-    def _vprint(self, s, newline=True):
-        '''Prints s, with optional newline. Intended for internal use
-        in displaying progress.'''
-        if self.verbose:
-            vprint(s, newline)
-        
     def gauss_code(self, **kwargs):
         '''
         Returns a :class:`~pyknotid.representations.gausscode.GaussCode`
@@ -487,5 +482,3 @@ class Link(object):
         gc = self.gauss_code(**kwargs)
         gc.simplify(verbose=self.verbose)
         return multivariate_alexander(gc, variables)
-
-        

--- a/pyknotid/spacecurves/spacecurve.py
+++ b/pyknotid/spacecurves/spacecurve.py
@@ -19,6 +19,7 @@ API documentation
 
 '''
 
+import logging
 import numpy as n
 import numpy as np
 import sys
@@ -26,7 +27,7 @@ import sys
 try:
     from pyknotid.spacecurves import chelpers
 except ImportError:
-    print('Could not import cythonised chelpers, using Python '
+    logging.warning('Could not import cythonised chelpers, using Python '
           'alternative. This will '
           'give the same result, but is slower.')
     from pyknotid.spacecurves import helpers as chelpers
@@ -132,15 +133,6 @@ class SpaceCurve(object):
         if fix_endpoints:
             points = np.vstack([points, points[:1]])
         self.points = points
-
-    def _vprint(self, s, newline=True):
-        '''Prints s, with optional newline. Intended for internal use
-        in displaying progress.'''
-        if self.verbose:
-            sys.stdout.write(s)
-            if newline:
-                sys.stdout.write('\n')
-            sys.stdout.flush()
 
     def _add_closure(self):
         closing_distance = mag(self.points[-1] - self.points[0])
@@ -348,8 +340,8 @@ class SpaceCurve(object):
         for i in range(num_strands):
             cur_strand = strands_by_initial_index[index]
             line.extend(cur_strand)
-            print('index is', index)
-            print('cur strand is', cur_strand)
+            logging.info('index is' + str(index))
+            logging.info('cur strand is' + str(cur_strand))
             index = int(np.round(cur_strand[-1][0])) - 1
 
         k = cls(n.array(line)*5.)
@@ -416,7 +408,7 @@ class SpaceCurve(object):
         tangents = np.roll(points, -1, axis=0) - points
         angles = np.arctan2(tangents[:, 1], tangents[:, 0])
 
-        print('angles', angles)
+        logging.info('angles' + str(angles))
 
         cuaps = []
 
@@ -505,7 +497,7 @@ class SpaceCurve(object):
         else:
             helpers_module = helpers
 
-        self._vprint('Finding crossings')
+        logging.info('Finding crossings')
 
         points = self.points
         segment_lengths = n.roll(points[:, :2], -1, axis=0) - points[:, :2]
@@ -526,8 +518,7 @@ class SpaceCurve(object):
         for i in range(len(points)-2):
             if self.verbose:
                 if i % 100 == 0:
-                    self._vprint('\ri = {} / {}'.format(i, numtries),
-                                 False)
+                    logging.info('\ri = {} / {}'.format(i, numtries))
             v0 = points[i]
             dv = points[(i+1) % len(points)] - v0
 
@@ -557,7 +548,7 @@ class SpaceCurve(object):
                 max_segment_length,
                 jump_mode))
 
-        self._vprint('\n{} crossings found\n'.format(len(crossings) / 2))
+        logging.info('\n{} crossings found\n'.format(len(crossings) / 2))
         crossings.sort(key=lambda s: s[0])
         crossings = n.array(crossings)
         self._crossings = crossings
@@ -714,7 +705,7 @@ class SpaceCurve(object):
         gc = Representation(crossings, verbose=self.verbose)
         self._representation = gc
         return gc
-        
+
 
     def planar_diagram(self, **kwargs):
         '''
@@ -840,7 +831,7 @@ class SpaceCurve(object):
         '''
         Loads knot points from the given csv file, and returns a
         :class:`SpaceCurve` with those points.
-        
+
         Arguments are passed straight to :func:`pyknot.io.from_csv`.
         '''
         return cls(from_csv(filen, **kwargs))
@@ -888,7 +879,7 @@ class SpaceCurve(object):
         from pyknotid.simplify.octree import OctreeCell
         for i in range(runs):
             if len(self.points) > 30:
-                self._vprint('\rRun {} of {}, {} points remain'.format(
+                logging.info('\rRun {} of {}, {} points remain'.format(
                     i, runs, len(self.points)))
 
             if rotate:
@@ -906,7 +897,7 @@ class SpaceCurve(object):
             if plot:
                 self.plot()
 
-        self._vprint('\nReduced to {} points'.format(len(self.points)))
+        logging.info('\nReduced to {} points'.format(len(self.points)))
 
     def arclength(self, include_closure=True):
         '''
@@ -1159,6 +1150,3 @@ class SpaceCurve(object):
         new_points[:, 2] = points[2]
 
         self.points = new_points
-
-
-

--- a/pyknotid/utils.py
+++ b/pyknotid/utils.py
@@ -5,6 +5,7 @@ Utility functions
 
 import sys
 import numpy as n
+import logging
 
 def vprint(string='', newline=True, condition=True):
     '''
@@ -24,10 +25,9 @@ def vprint(string='', newline=True, condition=True):
     '''
     if not condition:
         return
-    sys.stdout.write(string)
     if newline:
-        sys.stdout.write('\n')
-    sys.stdout.flush()
+        string += '\n'
+    logging.info(string)
 
 def mag(v):
     '''
@@ -51,7 +51,7 @@ def get_rotation_matrix(angles):
     angles : iterable
         The psi, theta and phi angles
     '''
-    
+
     phi, theta, psi = angles
     sin = n.sin
     cos = n.cos


### PR DESCRIPTION
When attempting to use the pyknotid library as part of a larger system, the continous printing of debug information is a little annoying. Particularly because python has the logging module as a standard library (the vprint functions which are scattered all through the code act as a miniature logging priority system).
Ideally all calls to:

 * vprint
 * print
 * stdout.write

should be replaced with calls to logging.info (one of the lowest priority messages). Users of the library can then configure the logging module to either display the information or to not.

I haven't replaced all the print statements here, only the ones that influence my intended use. More may change in the future if I start using other parts of the library. If someone is bored for several hours, the can go through the whole library.....