### PR TITLE
Convert deprecated numpy data types to built-in types

### DIFF
--- a/pyknotid/invariants.py
+++ b/pyknotid/invariants.py
@@ -28,7 +28,7 @@ from __future__ import print_function
 import subprocess
 import re
 import sympy as sym
-import numpy as n
+import numpy as np
 
 from pyknotid.utils import vprint
 
@@ -134,8 +134,8 @@ def _alexander_numpy(crossings, variable=-1.0, quadrant='lr'):
     '''
     import numpy as n
     num_crossings = int(len(crossings)/2)
-    dtype = n.complex if isinstance(variable, n.complex) else n.float
-    matrix = n.zeros((num_crossings, num_crossings), dtype=dtype)
+    dtype = complex if isinstance(variable, complex) else float
+    matrix = np.zeros((num_crossings, num_crossings), dtype=dtype)
     line_num = 0
     crossing_num_counter = 0
     crossing_dict = {}
@@ -167,15 +167,15 @@ def _alexander_numpy(crossings, variable=-1.0, quadrant='lr'):
             line_num += 1
             matrix[crossing_num, line_num % num_crossings] = new_mat_elt
     if quadrant == 'lr':
-        poly_val = n.linalg.det(matrix[1:, 1:])
+        poly_val = np.linalg.det(matrix[1:, 1:])
     elif quadrant == 'ur':
-        poly_val = n.linalg.det(matrix[:-1, 1:])
+        poly_val = np.linalg.det(matrix[:-1, 1:])
     elif quadrant == 'ul':
-        poly_val = n.linalg.det(matrix[:-1:, :-1])
+        poly_val = np.linalg.det(matrix[:-1:, :-1])
     elif quadrant == 'll':
-        poly_val = n.linalg.det(matrix[1:, :-1])
-    if not isinstance(poly_val, n.complex):
-        poly_val = n.abs(poly_val)
+        poly_val = np.linalg.det(matrix[1:, :-1])
+    if not isinstance(poly_val, complex):
+        poly_val = np.abs(poly_val)
     return poly_val
 
 
@@ -975,7 +975,7 @@ def _crossing_arrows_and_signs_numpy(gc, crossing_numbers):
             under_crossing_indices[row[0]] = i
         signs[row[0]] = row[2]
 
-    arrows = n.zeros((len(crossing_numbers), 3), dtype=n.long)
+    arrows = np.zeros((len(crossing_numbers), 3), dtype=np.longlong)
 
     for index, number in enumerate(crossing_numbers):
         row = arrows[index]
@@ -1311,7 +1311,7 @@ def self_linking(representation):
     slink_counter = 0        
 
     for crossing_number in representation.crossing_numbers:
-        occurences = n.where(gauss_code[0][:, 0] == crossing_number)[0]
+        occurences = np.where(gauss_code[0][:, 0] == crossing_number)[0]
         first_occurence = occurences[0]
         second_occurence = occurences[1]
         crossing_difference = second_occurence - first_occurence        

--- a/pyknotid/make/periodic_knot.py
+++ b/pyknotid/make/periodic_knot.py
@@ -8,7 +8,6 @@ pyknotid.spacecurves.periodic for topological analysis.
 
 '''
 
-import numpy as n
 import numpy as np
 from pyknotid.spacecurves.periodic import CellKnot, PeriodicKnot
 from pyknotid.make import trefoil as aperiodic_trefoil
@@ -31,28 +30,28 @@ def cell_trefoil2(num_points=40):
     points = aperiodic_trefoil(num_points) + 4
     points *= 10
 
-    end = n.zeros((30, 3), dtype=n.float)
+    end = np.zeros((30, 3), dtype=float)
     end_start = points[-1]
     end_prev = points[-2]
-    end[:, 0] = n.linspace(end_prev[0], end_start[0], 30)
-    end[:, 1] = n.linspace(end_prev[1], end_start[1], 30)
-    end[:, 2] = n.linspace(end_prev[2], 0, 30.)
+    end[:, 0] = np.linspace(end_prev[0], end_start[0], 30)
+    end[:, 1] = np.linspace(end_prev[1], end_start[1], 30)
+    end[:, 2] = np.linspace(end_prev[2], 0, 30.)
 
-    start = n.zeros((30, 3), dtype=n.float)
+    start = np.zeros((30, 3), dtype=float)
     start_start = points[0]
     start_prev = points[1]
-    start[:, 0] = n.linspace(start_start[0], start_prev[0], 30)
-    start[:, 1] = n.linspace(start_start[1], start_prev[1], 30)
-    start[:, 2] = n.linspace(79.99, start_prev[2], 30)
+    start[:, 0] = np.linspace(start_start[0], start_prev[0], 30)
+    start[:, 1] = np.linspace(start_start[1], start_prev[1], 30)
+    start[:, 2] = np.linspace(79.99, start_prev[2], 30)
 
-    points = n.vstack((start, points[1:-1], end))
+    points = np.vstack((start, points[1:-1], end))
 
     # points[0, -1] = 79
     # points[-1, -1] = 0
     return CellKnot.folding(points, 80)
 
 def simple_link():
-    points = n.array([[6, 1, 0],
+    points = np.array([[6, 1, 0],
                       [6, 2, 0],
                       [5, 2.5, 1],
                       [4, 3, 0],
@@ -68,14 +67,14 @@ def simple_link():
                       [6, 3, 0],
                       [6, 4, 0]])
 
-    points[:, 0] += 0.05*n.sin(n.linspace(0, 2*n.pi, len(points)))
-    points[:, 1] += 0.05*n.cos(n.linspace(0, 2*n.pi, len(points)))
-    points[:, 2] += 0.05*(n.sin(n.linspace(0, 2*n.pi, len(points))) * 
-                          n.cos(n.linspace(0, 2*n.pi, len(points))))
+    points[:, 0] += 0.05*np.sin(np.linspace(0, 2*np.pi, len(points)))
+    points[:, 1] += 0.05*np.cos(np.linspace(0, 2*np.pi, len(points)))
+    points[:, 2] += 0.05*(np.sin(np.linspace(0, 2*np.pi, len(points))) * 
+                          np.cos(np.linspace(0, 2*np.pi, len(points))))
     return points * 5
 
 def simple_link2():
-    points = n.array([[6, 1, 0],
+    points = np.array([[6, 1, 0],
                       [6, 2, 0],
                       [5, 2.5, 1],
                       [4, 3, 0],
@@ -91,15 +90,15 @@ def simple_link2():
                       [6, 3, 0],
                       [6, 4, 0]])
 
-    points[:, 0] += 0.05*n.sin(n.linspace(0, 2*n.pi, len(points)))
-    points[:, 1] += 0.05*n.cos(n.linspace(0, 2*n.pi, len(points)))
-    points[:, 2] += 0.05*(n.sin(n.linspace(0, 2*n.pi, len(points))) * 
-                          n.cos(n.linspace(0, 2*n.pi, len(points))))
+    points[:, 0] += 0.05*np.sin(np.linspace(0, 2*np.pi, len(points)))
+    points[:, 1] += 0.05*np.cos(np.linspace(0, 2*np.pi, len(points)))
+    points[:, 2] += 0.05*(np.sin(np.linspace(0, 2*np.pi, len(points))) * 
+                          np.cos(np.linspace(0, 2*np.pi, len(points))))
     
     return points * 5
 
 def p3_1():
-    points = n.array([[0, 0, 0],
+    points = np.array([[0, 0, 0],
                       [0, 2, 0],
                       [0, 3, 1],
                       [0, 4, 0],
@@ -120,7 +119,7 @@ def p3_1():
     return points * 5
 
 def p3_2():
-    points = n.array([[6, 1, 0],
+    points = np.array([[6, 1, 0],
                       [6, 2, 0],
                       [5, 2.5, 1],
                       [4, 3, 0],
@@ -136,14 +135,14 @@ def p3_2():
                       [6, 3, 0],
                       [6, 4, 0]])
 
-    points[:, 0] += 0.05*n.sin(n.linspace(0, 2*n.pi, len(points)))
-    points[:, 1] += 0.05*n.cos(n.linspace(0, 2*n.pi, len(points)))
-    points[:, 2] += 0.05*(n.sin(n.linspace(0, 2*n.pi, len(points))) * 
-                          n.cos(n.linspace(0, 2*n.pi, len(points))))
+    points[:, 0] += 0.05*np.sin(np.linspace(0, 2*np.pi, len(points)))
+    points[:, 1] += 0.05*np.cos(np.linspace(0, 2*np.pi, len(points)))
+    points[:, 2] += 0.05*(np.sin(np.linspace(0, 2*np.pi, len(points))) * 
+                          np.cos(np.linspace(0, 2*np.pi, len(points))))
     return points * 5
 
 def p3_3():
-    points = n.array([[6, 1, 0],
+    points = np.array([[6, 1, 0],
                       [6, 2, 0],
                       [5, 2.5, 1],
                       [4, 3, 0],
@@ -159,15 +158,15 @@ def p3_3():
                       [6, 3, 0],
                       [6, 4, 0]])
 
-    points[:, 0] += 0.05*n.sin(n.linspace(0, 2*n.pi, len(points)))
-    points[:, 1] += 0.05*n.cos(n.linspace(0, 2*n.pi, len(points)))
-    points[:, 2] += 0.05*(n.sin(n.linspace(0, 2*n.pi, len(points))) * 
-                          n.cos(n.linspace(0, 2*n.pi, len(points))))
+    points[:, 0] += 0.05*np.sin(np.linspace(0, 2*np.pi, len(points)))
+    points[:, 1] += 0.05*np.cos(np.linspace(0, 2*np.pi, len(points)))
+    points[:, 2] += 0.05*(np.sin(np.linspace(0, 2*np.pi, len(points))) * 
+                          np.cos(np.linspace(0, 2*np.pi, len(points))))
     
     return points * 5
 
 def p4_1():
-    points = n.array([[0, 0, 0],
+    points = np.array([[0, 0, 0],
                       [0, 1, 0],
                       [1, 2, 1],
                       [2, 3, 0],
@@ -193,7 +192,7 @@ def p4_1():
                       
 def _p4_something(*crossing_signs):
     s1, s2, s3, s4, s5, s6, s7, s8 = crossing_signs
-    points = n.array([[0, 0, 0.],
+    points = np.array([[0, 0, 0.],
                       [0, 3, 0],
                       [0, 5, 0],
                       [1, 6, s1],
@@ -317,13 +316,13 @@ def p5_3():
 #######################
 
 def p0_1():
-    points = n.array([[0, 0, 0],
+    points = np.array([[0, 0, 0],
                       [1, 5, 0],
                       [0, 10, 0]])
     return points
 
 def p3_1():
-    points = n.array([[0, 0, 0],
+    points = np.array([[0, 0, 0],
                       [0, 2, 0],
                       [0, 3, 1],
                       [0, 4, 0],
@@ -344,7 +343,7 @@ def p3_1():
     return points * 5
 
 def p3_2__1():
-    points = n.array([[6, 1, 0],
+    points = np.array([[6, 1, 0],
                       [6, 2, 0],
                       [5, 2.5, 1],
                       [4, 3, 0],
@@ -360,14 +359,14 @@ def p3_2__1():
                       [6, 3, 0],
                       [6, 4, 0]])
 
-    points[:, 0] += 0.05*n.sin(n.linspace(0, 2*n.pi, len(points)))
-    points[:, 1] += 0.05*n.cos(n.linspace(0, 2*n.pi, len(points)))
-    points[:, 2] += 0.05*(n.sin(n.linspace(0, 2*n.pi, len(points))) * 
-                          n.cos(n.linspace(0, 2*n.pi, len(points))))
+    points[:, 0] += 0.05*np.sin(np.linspace(0, 2*np.pi, len(points)))
+    points[:, 1] += 0.05*np.cos(np.linspace(0, 2*np.pi, len(points)))
+    points[:, 2] += 0.05*(np.sin(np.linspace(0, 2*np.pi, len(points))) * 
+                          np.cos(np.linspace(0, 2*np.pi, len(points))))
     return points * 5
 
 def p3_2__2():
-    points = n.array([[6, 1, 0],
+    points = np.array([[6, 1, 0],
                       [6, 2, 0],
                       [5, 2.5, 1],
                       [4, 3, 0],
@@ -383,15 +382,15 @@ def p3_2__2():
                       [6, 3, 0],
                       [6, 4, 0]])
 
-    points[:, 0] += 0.05*n.sin(n.linspace(0, 2*n.pi, len(points)))
-    points[:, 1] += 0.05*n.cos(n.linspace(0, 2*n.pi, len(points)))
-    points[:, 2] += 0.05*(n.sin(n.linspace(0, 2*n.pi, len(points))) * 
-                          n.cos(n.linspace(0, 2*n.pi, len(points))))
+    points[:, 0] += 0.05*np.sin(np.linspace(0, 2*np.pi, len(points)))
+    points[:, 1] += 0.05*np.cos(np.linspace(0, 2*np.pi, len(points)))
+    points[:, 2] += 0.05*(np.sin(np.linspace(0, 2*np.pi, len(points))) * 
+                          np.cos(np.linspace(0, 2*np.pi, len(points))))
     
     return points * 5
 
 def p4_1():
-    points = n.array([[0, 0, 0],
+    points = np.array([[0, 0, 0],
                       [0, 1, 0],
                       [1, 2, 1],
                       [2, 3, 0],

--- a/pyknotid/representations/dtnotation.py
+++ b/pyknotid/representations/dtnotation.py
@@ -9,7 +9,7 @@ API documentation
 ~~~~~~~~~~~~~~~~~
 '''
 
-import numpy as n
+import numpy as np
 import re
 import sys
 
@@ -32,7 +32,7 @@ class DTNotation(object):
     def __init__(self, code):
         if isinstance(code, string_types):
             self._init_from_string(code)
-        elif isinstance(code, n.ndarray):
+        elif isinstance(code, np.ndarray):
             code = [code]
             self._dt = code
         elif isinstance(code, list):
@@ -52,7 +52,7 @@ class DTNotation(object):
 
         for line in lines:
             numbers = line.split(' ')
-            dt.append(n.array([int(number) for number in numbers], dtype=n.int))
+            dt.append(np.array([int(number) for number in numbers], dtype=int))
 
         self._dt = dt
 
@@ -70,13 +70,13 @@ class DTNotation(object):
                              'work with links')
 
         dt = self._dt[0]
-        arr = n.zeros((len(dt) * 2, 2), dtype=n.int)
+        arr = np.zeros((len(dt) * 2, 2), dtype=int)
 
 
         for index, even in enumerate(dt, 0):
             odd = 2*index
-            sign = n.sign(even)
-            even = n.abs(even) - 1
+            sign = np.sign(even)
+            even = np.abs(even) - 1
 
             arr[odd, 0] = index + 1
             arr[odd, 1] = sign

--- a/pyknotid/representations/representation.py
+++ b/pyknotid/representations/representation.py
@@ -12,7 +12,7 @@ API documentation
 from __future__ import print_function, division
 from pyknotid.representations.gausscode import GaussCode
 from collections import defaultdict
-import numpy as n
+import numpy as np
 
 
 class Representation(GaussCode):
@@ -78,11 +78,11 @@ class Representation(GaussCode):
         '''
         if hasattr(root, '__contains__'):
             return [self.alexander_at_root(r) for r in root]
-        variable = n.exp(2 * n.pi * 1.j / root)
+        variable = np.exp(2 * np.pi * 1.j / root)
         value = self.alexander_polynomial(variable, **kwargs)
-        value = n.abs(value)
+        value = np.abs(value)
         if round and root in (1, 2, 3, 4):
-            value = int(n.round(value))
+            value = int(np.round(value))
         return value
 
     def vassiliev_degree_2(self, simplify=True):
@@ -247,7 +247,7 @@ class Representation(GaussCode):
         virtual = False
         
         for crossing_number in self.crossing_numbers:
-            occurences = n.where(gauss_code == crossing_number)[0]
+            occurences = np.where(gauss_code == crossing_number)[0]
             first_occurence = occurences[0]
             second_occurence = occurences[1]
             crossing_difference = second_occurence - first_occurence        
@@ -271,14 +271,14 @@ class Representation(GaussCode):
     def writhe(self):
         writhe = 0
 
-        return int(n.round(n.sum([n.sum(l[:, -1]) for l in self._gauss_code])/2.))
+        return int(np.round(np.sum([np.sum(l[:, -1]) for l in self._gauss_code])/2.))
 
     def slip_triangle(self, func):
 
         code = self._gauss_code[0]
 
         length = len(self)
-        array = n.ones((len(self) + 1, len(self) + 1)) * -0
+        array = np.ones((len(self) + 1, len(self) + 1)) * -0
         
         for i in range(length + 1):
             for j in range(length + 1):
@@ -351,8 +351,8 @@ class Representation(GaussCode):
 
         lines = []
 
-        rightmost_x = n.max(xs)
-        leftmost_x = n.min(xs)
+        rightmost_x = np.max(xs)
+        leftmost_x = np.min(xs)
         x_span = rightmost_x - leftmost_x
         safe_yshift = 0.5 / x_span
 
@@ -371,13 +371,13 @@ class Representation(GaussCode):
             start_left, start_right = node_lefts_rights[start_node]
             end_left, end_right = node_lefts_rights[end_node]
 
-            start_frac = n.abs((x - start_left) / (start_right - start_left) - 0.5)
+            start_frac = np.abs((x - start_left) / (start_right - start_left) - 0.5)
             start_frac = 0.5 - start_frac
             if True:  # ye < ys:  # This always evaluated to True - a bug?
                 start_frac *= -1
             start_shift = start_frac
 
-            end_frac = n.abs((x - end_left) / (end_right - end_left) - 0.5)
+            end_frac = np.abs((x - end_left) / (end_right - end_left) - 0.5)
             end_frac = 0.5 - end_frac
             if False:  # ye > ys:  # This always evaluated to False - a bug?
                 end_frac *= -1
@@ -389,7 +389,7 @@ class Representation(GaussCode):
             end_node_x = node_xs_by_y[ye]
             end_node_y = ye
 
-            line = n.array([[start_node_x, start_node_y],
+            line = np.array([[start_node_x, start_node_y],
                             [x, start_node_y - start_shift],
                             [x, end_node_y - end_shift],
                             [end_node_x, end_node_y]])
@@ -409,13 +409,13 @@ class Representation(GaussCode):
                 lx, hx = sorted([n1x, n2x])
                 ly, hy = sorted([n1y, n2y])
                 if len(line) == 4:
-                    join_1 = n.array([line[2, 0], line[2, 1], 0]) - n.array([line[0, 0], line[0, 1], 0])
-                    normal_1 = n.cross(join_1, [0, 0, 1])[:2]
-                    normal_1 /= n.linalg.norm(normal_1)
+                    join_1 = np.array([line[2, 0], line[2, 1], 0]) - np.array([line[0, 0], line[0, 1], 0])
+                    normal_1 = np.cross(join_1, [0, 0, 1])[:2]
+                    normal_1 /= np.linalg.norm(normal_1)
 
-                    join_2 = n.array([line[3, 0], line[3, 1], 0]) - n.array([line[1, 0], line[1, 1], 0])
-                    normal_2 = n.cross(join_2, [0, 0, 1])[:2]
-                    normal_2 /= n.linalg.norm(normal_2)
+                    join_2 = np.array([line[3, 0], line[3, 1], 0]) - np.array([line[1, 0], line[1, 1], 0])
+                    normal_2 = np.cross(join_2, [0, 0, 1])[:2]
+                    normal_2 /= np.linalg.norm(normal_2)
 
                     extra_x_shifts.append(line[1][0] + 0.005 * normal_1[0])
 
@@ -423,19 +423,19 @@ class Representation(GaussCode):
                     line[2] += 0.01*normal_2
 
                 elif len(line) == 3:
-                    join_1 = n.array([line[2, 0], line[2, 1], 0]) - n.array([line[0, 0], line[0, 1], 0])
-                    normal_1 = n.cross(join_1, [0, 0, 1])[:2]
-                    normal_1 /= n.linalg.norm(normal_1)
+                    join_1 = np.array([line[2, 0], line[2, 1], 0]) - np.array([line[0, 0], line[0, 1], 0])
+                    normal_1 = np.cross(join_1, [0, 0, 1])[:2]
+                    normal_1 /= np.linalg.norm(normal_1)
 
                     extra_x_shifts.append(line[1][0] + 0.005 * normal_1[0])
 
                     line[1] += 0.01*normal_1
                 elif len(line) == 2:
-                    join_1 = n.array([line[1, 0], line[1, 1], 0]) - n.array([line[0, 0], line[0, 1], 0])
-                    normal_1 = n.cross(join_1, [0, 0, 1])[:2]
-                    normal_1 /= n.linalg.norm(normal_1)
+                    join_1 = np.array([line[1, 0], line[1, 1], 0]) - np.array([line[0, 0], line[0, 1], 0])
+                    normal_1 = np.cross(join_1, [0, 0, 1])[:2]
+                    normal_1 /= np.linalg.norm(normal_1)
 
-                    line = n.vstack([line[0], line[0] + 0.5*(line[1] - line[0]) + 0.01*normal_1, line[1]])
+                    line = np.vstack([line[0], line[0] + 0.5*(line[1] - line[0]) + 0.01*normal_1, line[1]])
 
                     extra_x_shifts.append(line[1][0] - 0.005 * normal_1[0])
                 
@@ -485,11 +485,11 @@ class Representation(GaussCode):
         self.simplify()
 
         if len(self) == 0:
-            thetas = n.linspace(0, 2*n.pi, 10)
-            xs = n.sin(thetas) * 3
-            ys = n.cos(thetas) * 3
-            zs = n.zeros(10)
-            return Knot(n.vstack((xs, ys, zs)).T)
+            thetas = np.linspace(0, 2*np.pi, 10)
+            xs = np.sin(thetas) * 3
+            ys = np.cos(thetas) * 3
+            zs = np.zeros(10)
+            return Knot(np.vstack((xs, ys, zs)).T)
         
         # self.draw_planar_graph()
         g, lines, node_labels, nodes_by_height, xlims, first_edge, heights, extra_x_shifts = self._construct_planar_graph()
@@ -497,8 +497,8 @@ class Representation(GaussCode):
 
         cg = CrossingGraph()
         for line in lines:
-            start_node = nodes_by_height[n.int(n.round(line[0, 1]))]
-            end_node = nodes_by_height[n.int(n.round(line[-1, 1]))]
+            start_node = nodes_by_height[int(np.round(line[0, 1]))]
+            end_node = nodes_by_height[int(np.round(line[-1, 1]))]
             cl = CrossingLine(start_node, end_node, line)
             cg[start_node].append(cl)
             cg[end_node].append(cl.reversed())
@@ -566,7 +566,7 @@ class CrossingGraph(defaultdict):
         '''
         for key, value in self.items():
             self[key] = sorted(
-                value, key=lambda l: n.arctan2(l.points[1, 1] - l.points[0, 1],
+                value, key=lambda l: np.arctan2(l.points[1, 1] - l.points[0, 1],
                                                l.points[1, 0] - l.points[0, 0]))
 
     def retrieve_space_curve(self, first, next, initial_arc_number, heights):
@@ -609,7 +609,7 @@ class CrossingGraph(defaultdict):
         for _ in range(4*self.number_of_crossings()):
         # for _ in range(len(self)*2):
             current_points = current_line.points.copy()
-            ps = n.zeros((len(current_points), 3))
+            ps = np.zeros((len(current_points), 3))
             ps[:, :-1] = current_points
 
             height = heights[(current_line.start, current_line.end, arc_number)]
@@ -619,18 +619,18 @@ class CrossingGraph(defaultdict):
             segments.append(ps[:-1])
 
             next_lines = self[current_line.end]
-            incoming_angle = n.arctan2(current_points[-2, 1] - current_points[-1, 1],
+            incoming_angle = np.arctan2(current_points[-2, 1] - current_points[-1, 1],
                                        current_points[-2, 0] - current_points[-1, 0])
 
             other_incoming_angles = [
-                n.arctan2(l.points[1, 1] - l.points[0, 1],
+                np.arctan2(l.points[1, 1] - l.points[0, 1],
                           l.points[1, 0] - l.points[0, 0]) for l in next_lines]
 
             angle_distances = [
                 angle_distance(angle, incoming_angle)
                 for angle in other_incoming_angles]
 
-            incoming_index = n.argmin(angle_distances)
+            incoming_index = np.argmin(angle_distances)
             if len(angle_distances) == 4:
                 outgoing_index = (incoming_index + 2) % 4 
             elif len(angle_distances) == 2:
@@ -645,11 +645,11 @@ class CrossingGraph(defaultdict):
             if len(angle_distances) == 4:
                 arc_number = (arc_number % (2*self.number_of_crossings())) + 1
 
-        return n.vstack(segments)
+        return np.vstack(segments)
 
 def angle_distance(a1, a2):
-    dist = n.abs(a2 - a1)
-    if dist > n.pi:
-        dist = 2*n.pi - dist
+    dist = np.abs(a2 - a1)
+    if dist > np.pi:
+        dist = 2*np.pi - dist
     return dist
 

--- a/pyknotid/spacecurves/ccomplexity.pyx
+++ b/pyknotid/spacecurves/ccomplexity.pyx
@@ -13,7 +13,7 @@ cpdef cython_higher_order_writhe(double [:, :] points,
                         long [:] order):
 
     cdef long i1, i2, i3, i4
-    cdef long [:] indices = np.zeros(4, dtype=np.int)
+    cdef long [:] indices = np.zeros(4, dtype=int)
 
     cdef double writhe = 0.0
 
@@ -41,7 +41,7 @@ cpdef cython_second_order_writhes(double [:, :] points,
                                   double [:, :] contributions):
 
     cdef long i1, i2, i3, i4
-    cdef long [:] indices = np.zeros(4, dtype=np.int)
+    cdef long [:] indices = np.zeros(4, dtype=int)
 
     cdef double writhe_1 = 0.0
     cdef double writhe_2 = 0.0

--- a/pyknotid/spacecurves/periodiccell.py
+++ b/pyknotid/spacecurves/periodiccell.py
@@ -9,7 +9,6 @@ API documentation
 '''
 from pyknotid.utils import ensure_shape_tuple
 from pyknotid.spacecurves import Knot, OpenKnot
-import numpy as n
 import numpy as np
 
 class Cell(object):
@@ -137,7 +136,7 @@ class Cell(object):
         from pyknotid.spacecurves.openknot import OpenKnot
         lengths = []
         for line in self.lines:
-            points = n.vstack(line)
+            points = np.vstack(line)
             k = OpenKnot.from_periodic_line(points, self.shape,
                                             perturb=False)
             lengths.append(k.arclength())
@@ -284,20 +283,20 @@ class Cell(object):
 def _interpret_line(line):
     if isinstance(line, Knot):
         return line.points
-    elif isinstance(line, n.ndarray):
+    elif isinstance(line, np.ndarray):
         return line
 
     return ValueError('Lines must be Knots or ndarrays.')
 
 def _test_periodicity(line, shape):
-    closing_vector = (line[-1][-1] - line[0][0]) / n.array(shape)
-    if n.any(closing_vector > 0.2):
+    closing_vector = (line[-1][-1] - line[0][0]) / np.array(shape)
+    if np.any(closing_vector > 0.2):
         return 'nth'
     return 'loop'
 
 def _cut_line_at_jumps(line, shape):
     x, y, z = shape
-    shape = n.array(shape)
+    shape = np.array(shape)
     if x < 0 or y < 0 or z < 0:
         return line
     line = line.copy()
@@ -306,7 +305,7 @@ def _cut_line_at_jumps(line, shape):
     while i < (len(line)-1):
         cur = line[i]
         nex = line[i+1]
-        if n.any(n.abs(nex-cur) > 0.9*shape):
+        if np.any(np.abs(nex-cur) > 0.9*shape):
             first_half = line[:(i+1)]
             second_half = line[(i+1):]
             out.append(first_half)
@@ -319,10 +318,10 @@ def _cut_line_at_jumps(line, shape):
 
 def _cram_into_cell(line, shape):
     '''Imposes the shape as periodic boundary conditions.'''
-    shape = n.array(shape)
+    shape = np.array(shape)
     dx, dy, dz = shape
 
-    points = n.array(line).copy()
+    points = np.array(line).copy()
     for i in range(1, len(points)):
         prev = points[i-1]
         cur = points[i]
@@ -391,8 +390,8 @@ class BoundingBox(object):
             shape = float(shape[0])
 
         # should these have +1 and -1?
-        steps_mins = np.floor((b2.mins - b1.maxs) / shape).astype(np.int) + 1
-        steps_maxs = np.floor((b2.maxs - b1.mins) / shape).astype(np.int)
+        steps_mins = np.floor((b2.mins - b1.maxs) / shape).astype(int) + 1
+        steps_maxs = np.floor((b2.maxs - b1.mins) / shape).astype(int)
 
         return steps_mins, steps_maxs
 

--- a/pyknotid/spacecurves/spacecurve.py
+++ b/pyknotid/spacecurves/spacecurve.py
@@ -19,7 +19,6 @@ API documentation
 
 '''
 
-import numpy as n
 import numpy as np
 import sys
 
@@ -77,10 +76,10 @@ class SpaceCurve(object):
                  zero_centroid=False):
         if isinstance(points, SpaceCurve):
             points = points.points.copy()
-        self._points = n.zeros((0, 3))
+        self._points = np.zeros((0, 3))
         self._crossings = None  # Will store a list of crossings if
                                 # self.crossings() has been called
-        self.points = n.array(points).astype(n.float)
+        self.points = np.array(points).astype(float)
         self.verbose = verbose
 
         self._cached_writhe_and_crossing_numbers = None
@@ -145,7 +144,7 @@ class SpaceCurve(object):
     def _add_closure(self):
         closing_distance = mag(self.points[-1] - self.points[0])
         if closing_distance > 0.02:
-            self.points = n.vstack((self.points, self.points[:1] -
+            self.points = np.vstack((self.points, self.points[:1] -
                                     0.001*(self.points[0] - self.points[-1])))
 
     def _unwrap_periodicity(self, shape):
@@ -212,7 +211,7 @@ class SpaceCurve(object):
         '''
         com = ensure_shape_tuple(com)
 
-        points = line - n.array(com)
+        points = line - np.array(com)
 
         start = points[0]
         end = points[-1]
@@ -220,22 +219,22 @@ class SpaceCurve(object):
         start_r = mag(start)
         end_r = mag(end)
 
-        start_theta = n.arccos(start[2] / start_r)
-        end_theta = n.arccos(end[2] / end_r)
+        start_theta = np.arccos(start[2] / start_r)
+        end_theta = np.arccos(end[2] / end_r)
 
-        start_phi = n.arctan2(start[1], start[0])
-        end_phi = n.arctan2(end[1], end[0])
+        start_phi = np.arctan2(start[1], start[0])
+        end_phi = np.arctan2(end[1], end[0])
 
-        rs = n.linspace(end_r, start_r, 100)
-        thetas = n.linspace(end_theta, start_theta, 100)
-        phis = n.linspace(end_phi, start_phi, 100)
+        rs = np.linspace(end_r, start_r, 100)
+        thetas = np.linspace(end_theta, start_theta, 100)
+        phis = np.linspace(end_phi, start_phi, 100)
 
-        join_points = n.zeros((100, 3))
-        join_points[:, 2] = rs * n.cos(thetas)
-        join_points[:, 0] = rs * n.sin(thetas) * n.cos(phis)
-        join_points[:, 1] = rs * n.sin(thetas) * n.sin(phis)
+        join_points = np.zeros((100, 3))
+        join_points[:, 2] = rs * np.cos(thetas)
+        join_points[:, 0] = rs * np.sin(thetas) * np.cos(phis)
+        join_points[:, 1] = rs * np.sin(thetas) * np.sin(phis)
 
-        return cls(n.vstack((points, join_points[1:-1])) + n.array(com))
+        return cls(np.vstack((points, join_points[1:-1])) + np.array(com))
 
     @classmethod
     def from_periodic_line(cls, line, shape, perturb=True, **kwargs):
@@ -257,7 +256,7 @@ class SpaceCurve(object):
         knot = cls(line, **kwargs)
         knot._unwrap_periodicity(shape)
         if perturb:
-            knot.translate(n.array([0.00123, 0.00231, 0.00321]))
+            knot.translate(np.array([0.00123, 0.00231, 0.00321]))
             knot.rotate((0.0002, 0.0001, 0.0001))
         return knot
 
@@ -279,8 +278,8 @@ class SpaceCurve(object):
         :class:`SpaceCurve`
         '''
         knot = cls(line)
-        knot.translate(n.array([0.00123, 0.00231, 0.00321]))
-        knot.rotate(n.random.random(3) * 0.012)
+        knot.translate(np.array([0.00123, 0.00231, 0.00321]))
+        knot.rotate(np.random.random(3) * 0.012)
         return knot
 
     @classmethod
@@ -300,7 +299,7 @@ class SpaceCurve(object):
 
         num_strands = len(set(word.lower())) + 1
 
-        xs = n.arange(num_strands) + 1
+        xs = np.arange(num_strands) + 1
 
         y = 0.
 
@@ -352,7 +351,7 @@ class SpaceCurve(object):
             print('cur strand is', cur_strand)
             index = int(np.round(cur_strand[-1][0])) - 1
 
-        k = cls(n.array(line)*5.)
+        k = cls(np.array(line)*5.)
         k.zero_centroid()
         return k
 
@@ -373,14 +372,14 @@ class SpaceCurve(object):
         vector : array-like
             The x, y, z translation distances
         '''
-        self.points = self.points + n.array(vector)
+        self.points = self.points + np.array(vector)
 
     def zero_centroid(self):
         '''
         Translate such that the centroid (average position of vertices)
         is at (0, 0, 0).
         '''
-        centroid = n.average(self.points, axis=0)
+        centroid = np.average(self.points, axis=0)
         self.translate(-1*centroid)
 
     def rotate(self, angles=None):
@@ -394,7 +393,7 @@ class SpaceCurve(object):
             angles are used. Defaults to None.
         '''
         if angles is None:
-            angles = n.random.random(3)
+            angles = np.random.random(3)
         phi, theta, psi = angles
         rot_mat = get_rotation_matrix(angles)
         self._apply_matrix(rot_mat)
@@ -403,7 +402,7 @@ class SpaceCurve(object):
         '''
         Applies the given matrix to all of self.points.
         '''
-        self.points = n.apply_along_axis(mat.dot, 1, self.points)
+        self.points = np.apply_along_axis(mat.dot, 1, self.points)
 
     def cuaps(self, include_closure=True):
         '''Returns a list of the 'cuaps', where the curve is parallel to the
@@ -508,13 +507,13 @@ class SpaceCurve(object):
         self._vprint('Finding crossings')
 
         points = self.points
-        segment_lengths = n.roll(points[:, :2], -1, axis=0) - points[:, :2]
-        segment_lengths = n.sqrt(n.sum(segment_lengths * segment_lengths,
+        segment_lengths = np.roll(points[:, :2], -1, axis=0) - points[:, :2]
+        segment_lengths = np.sqrt(np.sum(segment_lengths * segment_lengths,
                                        axis=1))
         # if include_closure:
-        #     max_segment_length = n.max(segment_lengths)
+        #     max_segment_length = np.max(segment_lengths)
         # else:
-        max_segment_length = n.max(segment_lengths[:-1])
+        max_segment_length = np.max(segment_lengths[:-1])
 
         numtries = len(points) - 3
 
@@ -544,7 +543,7 @@ class SpaceCurve(object):
 
         if include_closure:
             closure_segment_length = segment_lengths[-1]
-            max_segment_length = n.max([closure_segment_length,
+            max_segment_length = np.max([closure_segment_length,
                                         max_segment_length])
             v0 = points[-1]
             dv = points[0] - v0
@@ -559,7 +558,7 @@ class SpaceCurve(object):
 
         self._vprint('\n{} crossings found\n'.format(len(crossings) / 2))
         crossings.sort(key=lambda s: s[0])
-        crossings = n.array(crossings)
+        crossings = np.array(crossings)
         self._crossings = crossings
 
         return crossings
@@ -579,7 +578,7 @@ class SpaceCurve(object):
             These are passed directly to :meth:`raw_crossings`.
         '''
         crossings = self.raw_crossings(**kwargs)
-        return n.sum(crossings[:, 3]) / 2.
+        return np.sum(crossings[:, 3]) / 2.
 
     def distance_quantity(self):
         from pyknotid.spacecurves.complexity import distance_quantity
@@ -635,7 +634,7 @@ class SpaceCurve(object):
 
     def second_order_twist(self, z):
         from pyknotid.spacecurves import complexity as com
-        z = np.array(z).astype(np.float)
+        z = np.array(z).astype(float)
         assert len(z) == 3
         return com.second_order_twist(self.points, z)
 
@@ -808,7 +807,7 @@ class SpaceCurve(object):
                 dr = points[(xint+1) % len(points)] - r
                 plot_crossings.append(r + (x-xint) * dr)
         fig, ax = plot_projection(points,
-                                  crossings=n.array(plot_crossings),
+                                  crossings=np.array(plot_crossings),
                                   mark_start=mark_start,
                                   mark_points=mark_points,
                                   fig_ax=fig_ax,
@@ -899,7 +898,7 @@ class SpaceCurve(object):
                     i, runs, len(self.points)))
 
             if rotate:
-                rot_mat = get_rotation_matrix(n.random.random(3))
+                rot_mat = get_rotation_matrix(np.random.random(3))
                 self._apply_matrix(rot_mat)
 
             oc = OctreeCell.from_single_line(self.points, **kwargs)
@@ -978,16 +977,16 @@ class SpaceCurve(object):
         indices = self._new_indices_by_arclength(num_points)
 
         interp_xs = interp1d(range(len(self.points)+1),
-                             n.hstack((self.points[:, 0],
+                             np.hstack((self.points[:, 0],
                                       self.points[:, 0][:1])))
         interp_ys = interp1d(range(len(self.points)+1),
-                             n.hstack((self.points[:, 1],
+                             np.hstack((self.points[:, 1],
                                       self.points[:, 1][:1])))
         interp_zs = interp1d(range(len(self.points)+1),
-                             n.hstack((self.points[:, 2],
+                             np.hstack((self.points[:, 2],
                                       self.points[:, 2][:1])))
 
-        new_points = n.zeros((len(indices), 3), dtype=n.float)
+        new_points = np.zeros((len(indices), 3), dtype=np.float)
         new_points[:, 0] = interp_xs(indices)
         new_points[:, 1] = interp_ys(indices)
         new_points[:, 2] = interp_zs(indices)
@@ -999,21 +998,21 @@ class SpaceCurve(object):
             number = len(self.points)
         total_arclength = self.arclength()
         if step is None:
-            arclengths = n.linspace(0, total_arclength - gap, number+1)[:-1]
+            arclengths = np.linspace(0, total_arclength - gap, number+1)[:-1]
         else:
-            arclengths = n.arange(0, total_arclength - gap, step)
+            arclengths = np.arange(0, total_arclength - gap, step)
 
         arclengths[0] += 0.000001
 
         points = self.points
         segment_arclengths = self.segment_arclengths()
-        cumulative_arclength = n.hstack([[0.], n.cumsum(segment_arclengths)])
+        cumulative_arclength = np.hstack([[0.], np.cumsum(segment_arclengths)])
         total_arclength = self.arclength()
 
         indices = []
 
         for arclength in arclengths:
-            first_greater_index = n.argmax(cumulative_arclength > arclength)
+            first_greater_index = np.argmax(cumulative_arclength > arclength)
             last_lower_index = (first_greater_index - 1) % len(points)
             arclength_below = cumulative_arclength[last_lower_index]
             step_arclength = segment_arclengths[last_lower_index]
@@ -1027,8 +1026,8 @@ class SpaceCurve(object):
         Returns an array of arclengths of every step in the line
         defined by self.points.
         '''
-        return n.apply_along_axis(
-            mag, 1, n.roll(self.points, -1, axis=0) - self.points)
+        return np.apply_along_axis(
+            mag, 1, np.roll(self.points, -1, axis=0) - self.points)
 
     def smooth(self, repeats=1, periodic=True, window_len=10,
                window='hanning'):
@@ -1055,7 +1054,7 @@ class SpaceCurve(object):
         '''
         points = self.points
         if periodic:
-            points = n.vstack((points[-(window_len + 1):],
+            points = np.vstack((points[-(window_len + 1):],
                                points,
                                points[:(window_len + 1)]))
         else:

--- a/tests/test_catalogue.py
+++ b/tests/test_catalogue.py
@@ -1,5 +1,3 @@
-
-
 import pyknotid.spacecurves.spacecurve as sp
 
 from functools import wraps

--- a/tests/test_knot.py
+++ b/tests/test_knot.py
@@ -1,4 +1,3 @@
-
 import pyknotid.spacecurves.knot as spknot
 import pyknotid.make as mk
 

--- a/tests/test_random_curves.py
+++ b/tests/test_random_curves.py
@@ -1,5 +1,3 @@
-
-
 import pyknotid.spacecurves.knot as spknot
 import pyknotid.make.randomwalks.quaternionic as rw
 

--- a/tests/test_spacecurve.py
+++ b/tests/test_spacecurve.py
@@ -1,5 +1,3 @@
-
-
 import pyknotid.spacecurves.spacecurve as sp
 import pyknotid.make as mk
 


### PR DESCRIPTION
Numpy deprecated and removed the `numpy.float`, `numpy.int`, `numpy.complex` and `numpy.long` data types. For the first three they were just aliases for the built-in types so they can safely converted to the built-in types in this commit. `numpy.long` is changed to the appropriate scalar type; `numpy.longlong`.

In all the files touched, duplicate numpy imports are removed. Typically there was both `import numpy as np` and `import numpy as n`. The former is preferred and used in all files touched by this commit.

### All tests pass

```
platform linux -- Python 3.11.1, pytest-7.2.1, pluggy-1.0.0
rootdir: /home/xavier/Checkout/pyknotid
collected 104 items                                                                                                                                                                            

test_catalogue.py .....................................................................................                                                      [ 81%]
test_knot.py ..                                                                                                                                                      [ 83%]
test_random_curves.py .                                                                                                                                   [ 84%]
test_spacecurve.py ................                                                                                                                          [100%]

104 passed in 2.89s
```